### PR TITLE
Fix typos in chapter 3 errors documentation

### DIFF
--- a/better-code/src/chapter-3-errors.md
+++ b/better-code/src/chapter-3-errors.md
@@ -573,12 +573,12 @@ calls attention to the error type introduced by `ThisModule`.
 
 ##### Documenting Mutating Functions
 
-When a runtime error occurs partway through a mutating operation, a a
+When a runtime error occurs partway through a mutating operation, a
 partially mutated state may be left behind. Trying to describe these
 states in detail is usually a bad idea.  Apart from the fact that
 such descriptions can be unmanageably complex—try to document the
-state of an array from partway through an aborted sorting operation—it
-is normally information no client can use.
+state of an array partway through an aborted sort—it is normally
+information no client can use.
 
 Partially documenting these states *can* be useful, however.  For
 example, [Swift's


### PR DESCRIPTION
Correct typos and improve clarity in prose.